### PR TITLE
Upgrade version to 0.6.4

### DIFF
--- a/bin/compile
+++ b/bin/compile
@@ -13,7 +13,7 @@ mkdir -p $CACHE_DIR $BIN_PATH
 if [ -f "$ENV_DIR/HEROKU_ANYCABLE_GO_VERSION" ]; then
   version=`cat $ENV_DIR/HEROKU_ANYCABLE_GO_VERSION`
 else
-  version="0.6.2"
+  version="0.6.4"
 fi
 
 ANYCABLE_GO_URL="https://github.com/anycable/anycable-go/releases/download/v$version/anycable-go-v$version-mrb-linux-amd64"

--- a/bin/compile
+++ b/bin/compile
@@ -17,7 +17,7 @@ else
 fi
 
 ANYCABLE_GO_URL="https://github.com/anycable/anycable-go/releases/download/v$version/anycable-go-v$version-mrb-linux-amd64"
-ANYCABLE_GO_CACHE="$CACHE_DIR/anycable-go-$version"
+ANYCABLE_GO_CACHE="$CACHE_DIR/anycable-go-mrb-$version"
 
 BIN_DIR=$(cd $(dirname $0); pwd)
 

--- a/bin/compile
+++ b/bin/compile
@@ -16,7 +16,7 @@ else
   version="0.6.2"
 fi
 
-ANYCABLE_GO_URL="https://github.com/anycable/anycable-go/releases/download/v$version/anycable-go-v$version-linux-amd64"
+ANYCABLE_GO_URL="https://github.com/anycable/anycable-go/releases/download/v$version/anycable-go-v$version-mrb-linux-amd64"
 ANYCABLE_GO_CACHE="$CACHE_DIR/anycable-go-$version"
 
 BIN_DIR=$(cd $(dirname $0); pwd)


### PR DESCRIPTION
## What's in this PR?
This PR was made to point the current buildpack for anycable to v0.6.4: https://github.com/anycable/anycable-go/releases/tag/v0.6.4

EDIT: Wrong repo, ignore this PR.